### PR TITLE
Add iglu server

### DIFF
--- a/config/iglu-server.hocon
+++ b/config/iglu-server.hocon
@@ -1,5 +1,5 @@
 repoServer {
-  port = 80
+  port = 8081
 }
 
 database {

--- a/config/iglu-server.hocon
+++ b/config/iglu-server.hocon
@@ -1,0 +1,13 @@
+repoServer {
+  port = 80
+}
+
+database {
+  type = "dummy"
+}
+
+debug = true
+
+# Super API Key is fixed for database.dummy
+# https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-server/setup/#dummy-mode
+#superApiKey = "48b267d7-cd2b-4f22-bae4-0f002008b5ad"

--- a/config/resolver.json
+++ b/config/resolver.json
@@ -22,6 +22,17 @@
             "uri": "http://iglu"
           }
         }
+      },
+      {
+        "name": "Local Iglu Server",
+        "priority": 2,
+        "vendorPrefixes": [ "com.dev" ],
+        "connection": {
+          "http": {
+            "uri": "http://iglu-server:8081",
+            "apikey": "48b267d7-cd2b-4f22-bae4-0f002008b5ad"
+          }
+        }
       }
     ]
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,15 @@ services:
     depends_on:
       - elasticsearch
 
+  iglu-server:
+    container_name: iglu-server
+    image: snowplow/iglu-server:latest
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./config:/snowplow/config
+    command: --config /snowplow/config/iglu-server.hocon
+
   iglu:
     container_name: iglu
     image: nginx


### PR DESCRIPTION
Currently, the docker-compose has the Nginx as a local iglu central mirror.
I'd like to add iglu server to be able to test interaction with the server in our local environment.